### PR TITLE
Añadir guia de maltergo

### DIFF
--- a/_data/recursos.yml
+++ b/_data/recursos.yml
@@ -20,6 +20,9 @@ Herramientas:
 
   - nombre: Nikto2
     url: https://cirt.net/Nikto2
+    
+  - nombre: Maltergo (Guia de Usuario)
+    url: https://docs.paterva.com/en/user-guide/
 
 Wargames:
   - nombre: Atenea


### PR DESCRIPTION
Tienen una guia buenísima y con imágenes.   No merece hacer una nueva
 
  - nombre: Maltergo (Guia de Usuario)
    url: https://docs.paterva.com/en/user-guide/